### PR TITLE
Refactor getCharacteristics to use optional binding

### DIFF
--- a/quick_blue/ios/Classes/SwiftQuickBluePlugin.swift
+++ b/quick_blue/ios/Classes/SwiftQuickBluePlugin.swift
@@ -22,18 +22,22 @@ extension CBPeripheral {
     }
   }
 
-  public func getCharacteristic(_ characteristic: String, of service: String) -> CBCharacteristic {
-    let s = self.services?.first {
-      $0.uuid.uuidStr == service || "0000\($0.uuid.uuidStr)-\(GSS_SUFFIX)" == service
+  public func getCharacteristic(_ characteristic: String, of service: String) -> CBCharacteristic? {
+    if let foundService = self.services?.first(where: {
+        $0.uuid.uuidStr == service || "0000\($0.uuid.uuidStr)-\(GSS_SUFFIX)" == service
+    }),
+    let foundCharacteristic = foundService.characteristics?.first(where: {
+        $0.uuid.uuidStr == characteristic || "0000\($0.uuid.uuidStr)-\(GSS_SUFFIX)" == characteristic
+    }) {
+        return foundCharacteristic
     }
-    let c = s?.characteristics?.first {
-      $0.uuid.uuidStr == characteristic || "0000\($0.uuid.uuidStr)-\(GSS_SUFFIX)" == characteristic
-    }
-    return c!
+    return nil
   }
 
   public func setNotifiable(_ bleInputProperty: String, for characteristic: String, of service: String) {
-    setNotifyValue(bleInputProperty != "disabled", for: getCharacteristic(characteristic, of: service))
+    guard let characteristic = getCharacteristic(characteristic, of: service) else { return }
+
+    setNotifyValue(bleInputProperty != "disabled", for: characteristic)
   }
 }
 
@@ -133,7 +137,8 @@ public class SwiftQuickBluePlugin: NSObject, FlutterPlugin {
         result(FlutterError(code: "IllegalArgument", message: "Unknown deviceId:\(deviceId)", details: nil))
         return
       }
-      peripheral.readValue(for: peripheral.getCharacteristic(characteristic, of: service))
+      guard let characteristic = peripheral.getCharacteristic(characteristic, of: service) else { return }
+      peripheral.readValue(for: characteristic)
       result(nil)
     case "writeValue":
       let arguments = call.arguments as! Dictionary<String, Any>
@@ -147,7 +152,8 @@ public class SwiftQuickBluePlugin: NSObject, FlutterPlugin {
         return
       }
       let type = bleOutputProperty == "withoutResponse" ? CBCharacteristicWriteType.withoutResponse : CBCharacteristicWriteType.withResponse
-      peripheral.writeValue(value.data, for: peripheral.getCharacteristic(characteristic, of: service), type: type)
+      guard let characteristic = peripheral.getCharacteristic(characteristic, of: service) else { return }
+      peripheral.writeValue(value.data, for: characteristic, type: type)
       result(nil)
     default:
       result(FlutterMethodNotImplemented)


### PR DESCRIPTION
quick_blue/SwiftQuickBluePlugin.swift:32: Fatal error: Unexpectedly found nil while unwrapping an Optional value

*thread 1, queue = 'com.apple.main-thread', stop reason = Fatal error: Unexpectedly found nil while unwrapping an Optional value
    frame #0: 0x00000001a327ca2c libswiftCore.dylib`_swift_runtime_on_report
libswiftCore.dylib`:
->  0x1a327ca2c <+0>: ret
libswiftCore.dylib`:
    0x1a327ca30 <+0>: b      0x1a327ca2c               ; _swift_runtime_on_report
libswiftCore.dylib`:
    0x1a327ca34 <+0>: adrp   x8, 366161
    0x1a327ca38 <+4>: ldrb   w0, [x8, #0x994]
Target 0: (Runner) stopped.